### PR TITLE
Document Engine deployment to ECS

### DIFF
--- a/document-engine/.gitignore
+++ b/document-engine/.gitignore
@@ -1,0 +1,58 @@
+#
+# Miscellaneous
+#
+signing-service/node_modules*
+
+#
+# Terraform 
+#
+# Local .terraform directories
+**/.terraform
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Don't save the lock
+*.terraform.lock.hcl
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+!terraform.tfvars
+!terraform.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Kubernetes
+.kubeconfig
+
+# SSH
+id_ed25519*
+
+# JWT Keys
+JWT_PRIVATE_KEY.key
+JWT_PUBLIC_KEY.pem

--- a/document-engine/README.md
+++ b/document-engine/README.md
@@ -1,0 +1,5 @@
+# Document Engine examples
+
+> [!NOTE] Document Engine [Reference Architecture](https://www.nutrient.io/guides/document-engine/self-hosted/reference-architecture/) examples 
+> are available here: https://github.com/PSPDFKit/document-engine-reference-architecture/
+

--- a/document-engine/de-aws-ecs-terraform/.tool-versions
+++ b/document-engine/de-aws-ecs-terraform/.tool-versions
@@ -1,0 +1,2 @@
+terraform 1.13.3
+awscli 2.30.6

--- a/document-engine/de-aws-ecs-terraform/LICENSE
+++ b/document-engine/de-aws-ecs-terraform/LICENSE
@@ -1,0 +1,42 @@
+The Nutrient Sample applications are licensed with a modified BSD
+license. In plain language: you're allowed to do whatever you wish
+with the code, modify, redistribute, embed in your products (free or
+commercial), but you must include copyright, terms of usage and
+disclaimer as stated in the license.
+
+You will require a commercial Nutrient License to run these examples
+in non-demo mode. Please refer to sales@nutrient.io for details.
+
+Copyright © 2018-present PSPDFKit GmbH.
+All rights reserved.
+
+Redistribution and use in source or binary forms,
+with or without modification, are permitted provided
+that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the
+  distribution.
+
+- Redistributions of Nutrient Samples must include attribution to
+  Nutrient, either in documentation or other appropriate media.
+
+- Neither the name of the Nutrient, PSPDFKit GmbH, nor its developers
+  may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/document-engine/de-aws-ecs-terraform/README.md
+++ b/document-engine/de-aws-ecs-terraform/README.md
@@ -25,9 +25,9 @@ The resources deployed will include:
 
 ## Notable limitations
 
+* No S3 bucket, using `built-in` storage
 * No HTTPS (requires a domain available)
-* No secret management (plain environment variables)
-* Unverified TLS with RDS (because need to provide AWS CA certificates)
+* No proper secret management (plain environment variables)
 
 ## Prerequisites
 

--- a/document-engine/de-aws-ecs-terraform/README.md
+++ b/document-engine/de-aws-ecs-terraform/README.md
@@ -76,7 +76,7 @@ Next, generate a JWT key pair using the `generate-jwt-pair.sh` script
 ```shell
 # Run from within examples/de-aws-eks
 
-../../scripts/generate-jwt-pair.sh
+./generate-jwt-pair.sh
 ```
 
 Finally, examine the plan and apply it:

--- a/document-engine/de-aws-ecs-terraform/README.md
+++ b/document-engine/de-aws-ecs-terraform/README.md
@@ -27,6 +27,7 @@ The resources deployed will include:
 
 * No HTTPS (requires a domain available)
 * No secret management (plain environment variables)
+* Unverified TLS with RDS (because need to provide AWS CA certificates)
 
 ## Prerequisites
 

--- a/document-engine/de-aws-ecs-terraform/README.md
+++ b/document-engine/de-aws-ecs-terraform/README.md
@@ -6,6 +6,7 @@
     - [Tools](#tools)
     - [Resources](#resources)
   - [Setup](#setup)
+    - [Required Variables](#required-variables)
   - [Accessing Document Engine](#accessing-document-engine)
   - [Cleanup](#cleanup)
   - [License](#license)
@@ -49,7 +50,7 @@ This entails something like this in `~/.aws/credentials`:
 ```
 [document-engine-example]
 aws_access_key_id = ...
-aws_secret_access_ke = ...
+aws_secret_access_key = ...
 ```
 
 ## Setup
@@ -63,7 +64,35 @@ export TF_VAR_aws_profile_name="document-engine-example"
 export TF_VAR_aws_region="eu-north-1" # Remove or change the default in `terraform.tfvars` file if setting this variable
 ```
 
-Alternatively, prepare to provide AWS profile name for interactive input during the following commands. 
+Alternatively, prepare to provide AWS profile name for interactive input during the following commands.
+
+### Required Variables
+
+Edit `terraform.tfvars` file if necessary:
+
+```hcl
+environment_name_prefix = "your-unique-prefix"
+
+document_engine_api_auth_token      = "your-api-auth-token"
+document_engine_dashboard_username  = "admin"
+document_engine_dashboard_password  = "your-secure-password"
+
+document_engine_parameters = {
+  image_tag           = "2024.9.0"
+  cpu                 = 1024
+  memory              = 2048
+  desired_count       = 1
+  logging_level       = "info"
+  port                = 5000
+  jwt_algorithm       = "RS256"
+  jwt_public_key_path = "./JWT_PUBLIC_KEY.pem"
+  extra_env           = {}
+}
+```
+
+> [!NOTE]
+> **Estimated monthly cost: ~$150-200** (RDS db.m8g.large + ALB + NAT Gateway)
+> Consider using smaller instance types like `db.t4g.micro` for testing.
 
 Put dependencies in place:
 
@@ -74,7 +103,7 @@ terraform init -upgrade
 Next, generate a JWT key pair using the `generate-jwt-pair.sh` script
 
 ```shell
-# Run from within examples/de-aws-eks
+# Run from within this directory
 
 ./generate-jwt-pair.sh
 ```

--- a/document-engine/de-aws-ecs-terraform/README.md
+++ b/document-engine/de-aws-ecs-terraform/README.md
@@ -90,35 +90,15 @@ Output should include deployment information:
 
 ```
 ...
-environment_name = "pspdfkit-de-demo-fE0JX8Bf"
-cluster_vpc_id = "vpc-0d00dfe0eee0641e4"
-...
-document_engine_url = "http://k8s-pspdfkit-document-1828531825-23172973189273.eu-north-1.elb.amazonaws.com"
-kubeconfig_command = "aws eks update-kubeconfig --region eu-north-1 --name pspdfkit-de-demo-fsd797d --kubeconfig .kubeconfig"
+document_engine_endpoint = "http://nutrient-de-demo-905380917.eu-north-1.elb.amazonaws.com:80"
 ```
-
-Note `kubeconfig_command` output, it contains AWS CLI command to retrieve Kubernetes configuration file. It can then be used by setting `KUBECONFIG` environment variable: 
-
-```shell
-aws eks update-kubeconfig --region eu-north-1 --name pspdfkit-de-demo-fsd797d --kubeconfig .kubeconfig
-export KUBECONFIG="$(pwd)/.kubeconfig"
-```
-
-This allows all range of `kubectl` and `helm` commands: 
-
-```shell
-kubectl get namespaces
-helm status -n pspdfkit-document-engine document-engine
-```
-
-We will need the URL from 
 
 ## Accessing Document Engine
 
-Terraform deployment output from the previous subsection should contain `document_engine_url` string. 
+Terraform deployment output from the previous subsection should contain `document_engine_endpoint` string. 
 It corresponds to [AWS Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) that exposes Document Engine. 
 
-Dashboard is accessible by `/dashboard` path, with default username `admin` and password `admin`.
+Dashboard is accessible by `/dashboard` path, with default username `admin` and password `nutrientAdmin!`, unless you changed it.
 
 ## Cleanup
 
@@ -134,7 +114,6 @@ This software is licensed under a [modified BSD license](LICENSE).
 
 ## Support, Issues and License Questions
 
-PSPDFKit offers support for customers with an active SDK license via https://pspdfkit.com/support/request/
+Nutrient offers support via https://support.nutrient.io/hc/en-us/requests/new
 
-Are you [evaluating our SDK](https://pspdfkit.com/try/)? That's great, we're happy to help out! To make sure this is fast, please use a work email and have someone from your company fill out our sales form: https://pspdfkit.com/sales/
-
+Are you [evaluating our SDK](https://www.nutrient.io/sdk/try)? That's great, we're happy to help out! To make sure this is fast, please use a work email and have someone from your company fill out our sales form: https://www.nutrient.io/contact-sales?=sdk

--- a/document-engine/de-aws-ecs-terraform/README.md
+++ b/document-engine/de-aws-ecs-terraform/README.md
@@ -1,0 +1,139 @@
+# Document Engine example — setting up AWS ECS cluster and deploying Document Engine
+
+- [Document Engine example — setting up AWS ECS cluster and deploying Document Engine](#document-engine-example--setting-up-aws-ecs-cluster-and-deploying-document-engine)
+  - [Notable limitations](#notable-limitations)
+  - [Prerequisites](#prerequisites)
+    - [Tools](#tools)
+    - [Resources](#resources)
+  - [Setup](#setup)
+  - [Accessing Document Engine](#accessing-document-engine)
+  - [Cleanup](#cleanup)
+  - [License](#license)
+  - [Support, Issues and License Questions](#support-issues-and-license-questions)
+
+> [!WARNING]
+> This is not a production configuration or a building block. 
+> It is intended for educational use, or as a starting point for a more complete infrastructure design.
+
+This example demonstrates minimal installation of [Nutrient Document Engine](https://www.nutrient.io/guides/document-engine/) in AWS using Terraform.
+
+The resources deployed will include:
+ * [AWS Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/Welcome.html) cluster as means of container orchestration
+   * Addons to integrate Amazon resources for logging and load balancing
+ * PostgreSQL database running on [AWS Relational Database Service](https://aws.amazon.com/rds/)
+ * [Nutrient Document Engine](https://www.nutrient.io/guides/document-engine/)
+
+## Notable limitations
+
+* No HTTPS (requires a domain available)
+* No secret management (plain environment variables)
+
+## Prerequisites
+
+### Tools
+
+* [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+
+### Resources
+
+You will need an AWS account, and a [profile set for it](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-using-profiles).
+
+You can use the AWS CLI to set this up by running `aws configure --profile document-engine-example`. After running this command, the configuration wizard will guide you through setting up the profile. 
+
+Or you can manually edit the `~/.aws/*` configuration files. 
+This entails something like this in `~/.aws/credentials`:
+
+
+```
+[document-engine-example]
+aws_access_key_id = ...
+aws_secret_access_ke = ...
+```
+
+## Setup
+
+Clone this repository.
+
+Prepare Terraform environment by setting the AWS profile and (optionally) region to use. This can be done by setting environment variables:
+
+```shell
+export TF_VAR_aws_profile_name="document-engine-example"
+export TF_VAR_aws_region="eu-north-1" # Remove or change the default in `terraform.tfvars` file if setting this variable
+```
+
+Alternatively, prepare to provide AWS profile name for interactive input during the following commands. 
+
+Put dependencies in place:
+
+```shell
+terraform init -upgrade
+```
+
+Next, generate a JWT key pair using the `generate-jwt-pair.sh` script
+
+```shell
+# Run from within examples/de-aws-eks
+
+../../scripts/generate-jwt-pair.sh
+```
+
+Finally, examine the plan and apply it:
+
+```shell
+terraform plan
+terraform apply
+```
+
+Output should include deployment information: 
+
+```
+...
+environment_name = "pspdfkit-de-demo-fE0JX8Bf"
+cluster_vpc_id = "vpc-0d00dfe0eee0641e4"
+...
+document_engine_url = "http://k8s-pspdfkit-document-1828531825-23172973189273.eu-north-1.elb.amazonaws.com"
+kubeconfig_command = "aws eks update-kubeconfig --region eu-north-1 --name pspdfkit-de-demo-fsd797d --kubeconfig .kubeconfig"
+```
+
+Note `kubeconfig_command` output, it contains AWS CLI command to retrieve Kubernetes configuration file. It can then be used by setting `KUBECONFIG` environment variable: 
+
+```shell
+aws eks update-kubeconfig --region eu-north-1 --name pspdfkit-de-demo-fsd797d --kubeconfig .kubeconfig
+export KUBECONFIG="$(pwd)/.kubeconfig"
+```
+
+This allows all range of `kubectl` and `helm` commands: 
+
+```shell
+kubectl get namespaces
+helm status -n pspdfkit-document-engine document-engine
+```
+
+We will need the URL from 
+
+## Accessing Document Engine
+
+Terraform deployment output from the previous subsection should contain `document_engine_url` string. 
+It corresponds to [AWS Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) that exposes Document Engine. 
+
+Dashboard is accessible by `/dashboard` path, with default username `admin` and password `admin`.
+
+## Cleanup
+
+To remove the resources created above: 
+
+```shell
+terraform destroy
+```
+
+## License
+
+This software is licensed under a [modified BSD license](LICENSE).
+
+## Support, Issues and License Questions
+
+PSPDFKit offers support for customers with an active SDK license via https://pspdfkit.com/support/request/
+
+Are you [evaluating our SDK](https://pspdfkit.com/try/)? That's great, we're happy to help out! To make sure this is fast, please use a work email and have someone from your company fill out our sales form: https://pspdfkit.com/sales/
+

--- a/document-engine/de-aws-ecs-terraform/database.tf
+++ b/document-engine/de-aws-ecs-terraform/database.tf
@@ -1,0 +1,68 @@
+locals {
+  document_engine_db_password_version = 1 # for rotation
+  document_engine_db_password         = sensitive(random_password.document_engine_db_password.result)
+
+  database_properties = {
+    identifier                   = "${local.environment_name}-db"
+    username                     = "nutrient"
+    db_name                      = "nutrient"
+    ec2_instance_type            = "db.m8g.large"
+    postgres_engine_version      = "17.5"
+    postgres_parameter_family    = "postgres17"
+    preferred_maintenance_window = "sun:05:00-sun:06:00"
+    skip_final_snapshot          = true
+  }
+}
+
+resource "random_password" "document_engine_db_password" {
+  length  = 60
+  special = false
+
+  keepers = {
+    version = local.document_engine_db_password_version
+  }
+}
+
+resource "aws_db_parameter_group" "document_engine" {
+  name   = local.database_properties.identifier
+  family = local.database_properties.postgres_parameter_family
+
+  parameter {
+    name  = "log_connections"
+    value = "1"
+  }
+}
+
+resource "aws_db_instance" "document_engine" {
+  identifier           = local.database_properties.identifier
+  instance_class       = local.database_properties.ec2_instance_type
+  allocated_storage    = 10
+  engine               = "postgres"
+  engine_version       = local.database_properties.postgres_engine_version
+  username             = local.database_properties.username
+  password             = local.document_engine_db_password
+  db_name              = local.database_properties.db_name
+  db_subnet_group_name = module.cluster_vpc.database_subnet_group_name
+  storage_encrypted    = true
+  vpc_security_group_ids = [
+    aws_security_group.document_engine_db_access.id
+  ]
+  parameter_group_name = aws_db_parameter_group.document_engine.name
+  publicly_accessible  = false
+  skip_final_snapshot  = local.database_properties.skip_final_snapshot
+}
+
+resource "aws_security_group" "document_engine_db_access" {
+  name_prefix = "${local.environment_name}-database-"
+  vpc_id      = module.cluster_vpc.vpc_id
+  description = "Allow access to the Document Engine database"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "document_engine_db_access" {
+  description                  = "Allow things in ECS to poke the database"
+  security_group_id            = aws_security_group.document_engine_db_access.id
+  referenced_security_group_id = module.ecs_document_engine_service.security_group_id
+  ip_protocol                  = "tcp"
+  from_port                    = aws_db_instance.document_engine.port
+  to_port                      = aws_db_instance.document_engine.port
+}

--- a/document-engine/de-aws-ecs-terraform/database.tf
+++ b/document-engine/de-aws-ecs-terraform/database.tf
@@ -11,6 +11,7 @@ locals {
     postgres_parameter_family    = "postgres17"
     preferred_maintenance_window = "sun:05:00-sun:06:00"
     skip_final_snapshot          = true
+    apply_immediately            = true
   }
 }
 
@@ -38,6 +39,7 @@ resource "aws_db_instance" "document_engine" {
   instance_class       = local.database_properties.ec2_instance_type
   allocated_storage    = 10
   engine               = "postgres"
+  ca_cert_identifier   = "rds-ca-rsa4096-g1"
   engine_version       = local.database_properties.postgres_engine_version
   username             = local.database_properties.username
   password             = local.document_engine_db_password
@@ -50,6 +52,7 @@ resource "aws_db_instance" "document_engine" {
   parameter_group_name = aws_db_parameter_group.document_engine.name
   publicly_accessible  = false
   skip_final_snapshot  = local.database_properties.skip_final_snapshot
+  apply_immediately    = local.database_properties.apply_immediately
 }
 
 resource "aws_security_group" "document_engine_db_access" {

--- a/document-engine/de-aws-ecs-terraform/database.tf
+++ b/document-engine/de-aws-ecs-terraform/database.tf
@@ -13,6 +13,8 @@ locals {
     skip_final_snapshot          = true
     apply_immediately            = true
   }
+
+  database_ca_certificates = data.http.aws_certificates_rds.response_body
 }
 
 resource "random_password" "document_engine_db_password" {
@@ -68,4 +70,8 @@ resource "aws_vpc_security_group_ingress_rule" "document_engine_db_access" {
   ip_protocol                  = "tcp"
   from_port                    = aws_db_instance.document_engine.port
   to_port                      = aws_db_instance.document_engine.port
+}
+
+data "http" "aws_certificates_rds" {
+  url = "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
 }

--- a/document-engine/de-aws-ecs-terraform/document_engine_service.tf
+++ b/document-engine/de-aws-ecs-terraform/document_engine_service.tf
@@ -10,6 +10,18 @@ locals {
     }] : [],
     [
       {
+        name  = "API_AUTH_TOKEN"
+        value = var.document_engine_api_auth_token
+      },
+      {
+        name  = "DASHBOARD_USERNAME"
+        value = var.document_engine_dashboard_username
+      },
+      {
+        name  = "DASHBOARD_PASSWORD"
+        value = var.document_engine_dashboard_password
+      },
+      {
         name  = "LOG_LEVEL"
         value = var.document_engine_parameters.logging_level
       },
@@ -71,8 +83,11 @@ module "ecs_document_engine_service" {
   name        = "document-engine"
   cluster_arn = module.ecs_cluster.arn
 
-  cpu    = var.document_engine_parameters.cpu
-  memory = var.document_engine_parameters.memory
+  cpu                      = var.document_engine_parameters.cpu
+  memory                   = var.document_engine_parameters.memory
+  autoscaling_min_capacity = var.document_engine_parameters.desired_count
+  autoscaling_max_capacity = var.document_engine_parameters.desired_count
+  desired_count            = var.document_engine_parameters.desired_count
 
   container_definitions = {
 

--- a/document-engine/de-aws-ecs-terraform/document_engine_service.tf
+++ b/document-engine/de-aws-ecs-terraform/document_engine_service.tf
@@ -42,6 +42,14 @@ locals {
         value = "true"
       },
       {
+        name  = "PGSSL_DISABLE_VERIFY"
+        value = "true"
+      },
+      # {
+      #   name  = "PGSSL_CA_CERTS"
+      #   value = local.database_ca_certificates
+      # },
+      {
         name  = "ASSET_STORAGE_BACKEND"
         value = "built-in"
       }

--- a/document-engine/de-aws-ecs-terraform/document_engine_service.tf
+++ b/document-engine/de-aws-ecs-terraform/document_engine_service.tf
@@ -61,14 +61,14 @@ locals {
         name  = "PGSSL"
         value = "true"
       },
-      {
-        name  = "PGSSL_DISABLE_VERIFY"
-        value = "true"
-      },
       # {
-      #   name  = "PGSSL_CA_CERTS"
-      #   value = local.database_ca_certificates
+      #   name  = "PGSSL_DISABLE_VERIFY"
+      #   value = "true"
       # },
+      {
+        name  = "PGSSL_CA_CERTS"
+        value = local.database_ca_certificates
+      },
       {
         name  = "ASSET_STORAGE_BACKEND"
         value = "built-in"
@@ -79,6 +79,7 @@ locals {
       value = v
     }]
   )
+  document_engine_secrets = []
 }
 
 module "ecs_document_engine_service" {
@@ -108,6 +109,7 @@ module "ecs_document_engine_service" {
       memoryReservation = 100
 
       environment = local.document_engine_environment
+      secrets     = local.document_engine_secrets
 
       portMappings = [
         {

--- a/document-engine/de-aws-ecs-terraform/document_engine_service.tf
+++ b/document-engine/de-aws-ecs-terraform/document_engine_service.tf
@@ -86,7 +86,7 @@ module "ecs_document_engine_service" {
         }
       ]
 
-      readonlyRootFilesystem = true
+      readonlyRootFilesystem = false
 
       enable_cloudwatch_logging        = true
       cloudwatch_log_group_name        = local.document_engine_cloudwatch_log_group_name

--- a/document-engine/de-aws-ecs-terraform/document_engine_service.tf
+++ b/document-engine/de-aws-ecs-terraform/document_engine_service.tf
@@ -14,6 +14,14 @@ locals {
         value = var.document_engine_api_auth_token
       },
       {
+        name  = "JWT_ALGORITHM"
+        value = var.document_engine_parameters.jwt_algorithm
+      },
+      {
+        name  = "JWT_PUBLIC_KEY"
+        value = file(var.document_engine_parameters.jwt_public_key_path)
+      },
+      {
         name  = "DASHBOARD_USERNAME"
         value = var.document_engine_dashboard_username
       },

--- a/document-engine/de-aws-ecs-terraform/ecs_cluster.tf
+++ b/document-engine/de-aws-ecs-terraform/ecs_cluster.tf
@@ -1,0 +1,84 @@
+#
+# https://registry.terraform.io/modules/terraform-aws-modules/ecs/aws/latest
+# https://github.com/terraform-aws-modules/terraform-aws-ecs
+#
+locals {
+  environment_name = (
+    var.environment_name == null ?
+    "${var.environment_name_prefix}-${random_string.cluster_suffix.result}" :
+    var.environment_name
+  )
+
+  ecs_cluster_cloudwatch_log_group_name     = "/aws/ecs/${local.environment_name}"
+  document_engine_cloudwatch_log_group_name = "/aws/document-engine/${local.environment_name}"
+}
+
+resource "random_string" "cluster_suffix" {
+  length  = 5
+  special = false
+}
+
+module "ecs_cluster" {
+  source = "terraform-aws-modules/ecs/aws//modules/cluster"
+
+  name = local.environment_name
+
+  cloudwatch_log_group_name              = local.ecs_cluster_cloudwatch_log_group_name
+  cloudwatch_log_group_retention_in_days = var.log_retention_days
+  configuration = {
+    execute_command_configuration = {
+      kms_key_id = aws_kms_key.ecs_cluster["main"].key_id
+      logging    = "OVERRIDE"
+      log_configuration = {
+        cloud_watch_log_group_name = local.ecs_cluster_cloudwatch_log_group_name
+      }
+    }
+    managed_storage_configuration = {
+      fargate_ephemeral_storage_kms_key_id = aws_kms_key.ecs_cluster["fargate_ephemeral_storage"].key_id
+      kms_key_id                           = aws_kms_key.ecs_cluster["managed_storage"].key_id
+    }
+  }
+  setting = [
+    {
+      "name" : "containerInsights",
+      "value" : "enabled"
+    }
+  ]
+
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-capacity-providers.html
+  default_capacity_provider_strategy = {
+    FARGATE = {
+      weight = 50
+      base   = 20
+    }
+    FARGATE_SPOT = {
+      weight = 50
+    }
+  }
+
+  tags = var.tags
+}
+
+# 
+locals {
+  ecs_kms_key_keys = [
+    "main",
+    "managed_storage",
+    "fargate_ephemeral_storage"
+  ]
+}
+
+resource "aws_kms_key" "ecs_cluster" {
+  for_each = toset(local.ecs_kms_key_keys)
+
+  description             = "ECS cluster key: ${local.environment_name} - ${each.key}"
+  enable_key_rotation     = true
+  deletion_window_in_days = 10
+}
+
+resource "aws_kms_alias" "ecs_cluster" {
+  for_each = toset(local.ecs_kms_key_keys)
+
+  name_prefix   = "alias/${local.environment_name}-${each.key}-"
+  target_key_id = aws_kms_key.ecs_cluster[each.key].id
+}

--- a/document-engine/de-aws-ecs-terraform/ecs_cluster.tf
+++ b/document-engine/de-aws-ecs-terraform/ecs_cluster.tf
@@ -34,7 +34,7 @@ module "ecs_cluster" {
       }
     }
     managed_storage_configuration = {
-      fargate_ephemeral_storage_kms_key_id = aws_kms_key.ecs_cluster["fargate_ephemeral_storage"].key_id
+      fargate_ephemeral_storage_kms_key_id = aws_kms_key.ecs_cluster["fargate_ephemeral_storage"].arn
       kms_key_id                           = aws_kms_key.ecs_cluster["managed_storage"].key_id
     }
   }
@@ -55,8 +55,6 @@ module "ecs_cluster" {
       weight = 50
     }
   }
-
-  tags = var.tags
 }
 
 # 

--- a/document-engine/de-aws-ecs-terraform/ecs_service.tf
+++ b/document-engine/de-aws-ecs-terraform/ecs_service.tf
@@ -1,0 +1,136 @@
+#
+# https://registry.terraform.io/modules/terraform-aws-modules/ecs/aws/latest
+# https://github.com/terraform-aws-modules/terraform-aws-ecs
+#
+locals {
+  document_engine_environment = concat(
+    var.document_engine_activation_key != null ? [{
+      name  = "ACTIVATION_KEY"
+      value = var.document_engine_activation_key
+    }] : [],
+    [
+      {
+        name  = "LOG_LEVEL"
+        value = var.document_engine_parameters.logging_level
+      },
+      {
+        name  = "PORT"
+        value = var.document_engine_parameters.port
+      },
+      {
+        name  = "PGHOST"
+        value = aws_db_instance.document_engine.address
+      },
+      {
+        name  = "PGPORT"
+        value = aws_db_instance.document_engine.port
+      },
+      {
+        name  = "PGDATABASE"
+        value = aws_db_instance.document_engine.db_name
+      },
+      {
+        name  = "PGUSER"
+        value = aws_db_instance.document_engine.username
+      },
+      {
+        name  = "PGPASSWORD"
+        value = local.document_engine_db_password
+      },
+      {
+        name  = "PGSSL"
+        value = "true"
+      },
+      {
+        name  = "ASSET_STORAGE_BACKEND"
+        value = "built-in"
+      }
+    ],
+    [for k, v in var.document_engine_parameters.extra_env : {
+      name  = k
+      value = v
+    }]
+  )
+}
+
+module "ecs_document_engine_service" {
+  depends_on = [
+    module.alb
+  ]
+
+  source = "terraform-aws-modules/ecs/aws//modules/service"
+
+  name        = "document-engine"
+  cluster_arn = module.ecs_cluster.arn
+
+  cpu    = var.document_engine_parameters.cpu
+  memory = var.document_engine_parameters.memory
+
+  container_definitions = {
+
+    document-engine = {
+      essential = true
+      image     = "public.ecr.aws/pspdfkit/document-engine:${var.document_engine_parameters.image_tag}"
+
+      cpu               = var.document_engine_parameters.cpu
+      memory            = var.document_engine_parameters.memory
+      memoryReservation = 100
+
+      environment = local.document_engine_environment
+
+      portMappings = [
+        {
+          name          = "api"
+          containerPort = var.document_engine_parameters.port
+          protocol      = "tcp"
+        }
+      ]
+
+      readonlyRootFilesystem = true
+
+      enable_cloudwatch_logging        = true
+      cloudwatch_log_group_name        = local.document_engine_cloudwatch_log_group_name
+      create_cloudwatch_log_group      = true
+      cloudwatch_log_retention_in_days = var.log_retention_days
+
+      restartPolicy = {
+        enabled = true
+        # ignoredExitCodes     = [1]
+        restartAttemptPeriod = 60
+      }
+    }
+  }
+
+  subnet_ids = module.cluster_vpc.private_subnets
+
+  load_balancer = {
+    service = {
+      target_group_arn = module.alb.target_groups["document-engine"].arn
+      container_name   = "document-engine"
+      container_port   = var.document_engine_parameters.port
+    }
+  }
+
+  security_group_ingress_rules = {
+    alb = {
+      description                  = "Service port"
+      from_port                    = var.document_engine_parameters.port
+      ip_protocol                  = "tcp"
+      referenced_security_group_id = aws_security_group.document_engine_alb.id
+    }
+  }
+  security_group_egress_rules = {
+    all = {
+      ip_protocol = "-1"
+      cidr_ipv4   = "0.0.0.0/0"
+    }
+  }
+
+  security_group_ids = []
+}
+
+resource "aws_security_group" "document_engine_alb" {
+  name_prefix = "${local.environment_name}-de-alb-"
+  vpc_id      = module.cluster_vpc.vpc_id
+  description = "Allow access to the Document Engine"
+}

--- a/document-engine/de-aws-ecs-terraform/generate-jwt-pair.sh
+++ b/document-engine/de-aws-ecs-terraform/generate-jwt-pair.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PUBLIC_KEY_NAME=JWT_PUBLIC_KEY.pem
+PRIVATE_KEY_NAME=JWT_PRIVATE_KEY.key
+
+# Generate the private key
+openssl genpkey -algorithm RSA -out "${PRIVATE_KEY_NAME}" -pkeyopt rsa_keygen_bits:2048
+
+# Set permissions for the private key
+chmod 600 "${PRIVATE_KEY_NAME}"
+
+# Generate public key from private key
+openssl rsa -in "${PRIVATE_KEY_NAME}" -pubout -outform PEM -out "${PUBLIC_KEY_NAME}"

--- a/document-engine/de-aws-ecs-terraform/load_balancer.tf
+++ b/document-engine/de-aws-ecs-terraform/load_balancer.tf
@@ -1,0 +1,67 @@
+#
+# https://registry.terraform.io/modules/terraform-aws-modules/alb/aws/latest
+# https://github.com/terraform-aws-modules/terraform-aws-alb
+#
+module "alb" {
+  source = "terraform-aws-modules/alb/aws"
+
+  name = local.environment_name
+
+  load_balancer_type = "application"
+
+  vpc_id  = module.cluster_vpc.vpc_id
+  subnets = module.cluster_vpc.public_subnets
+
+  enable_deletion_protection = false
+
+  security_group_ingress_rules = {
+    all_http = {
+      from_port   = 80
+      to_port     = 80
+      ip_protocol = "tcp"
+      cidr_ipv4   = "0.0.0.0/0"
+    }
+  }
+  security_group_egress_rules = {
+    all = {
+      ip_protocol = "-1"
+      cidr_ipv4   = module.cluster_vpc.vpc_cidr_block
+    }
+  }
+
+  listeners = {
+    ex_http = {
+      port     = 80
+      protocol = "HTTP"
+      forward = {
+        target_group_key = "document-engine"
+      }
+    }
+  }
+  target_groups = {
+    document-engine = {
+      backend_protocol                  = "HTTP"
+      backend_port                      = var.document_engine_parameters.port
+      target_type                       = "ip"
+      deregistration_delay              = 5
+      load_balancing_cross_zone_enabled = true
+
+      health_check = {
+        enabled             = true
+        healthy_threshold   = 5
+        interval            = 30
+        matcher             = "200"
+        path                = "/healthcheck"
+        port                = "traffic-port"
+        protocol            = "HTTP"
+        timeout             = 5
+        unhealthy_threshold = 2
+      }
+      create_attachment = false
+    }
+  }
+
+  security_groups = [
+    aws_security_group.document_engine_alb.id
+  ]
+}

--- a/document-engine/de-aws-ecs-terraform/outputs.tf
+++ b/document-engine/de-aws-ecs-terraform/outputs.tf
@@ -32,3 +32,11 @@ output "cluster_name" {
   description = "Name of the ECS cluster"
   value       = module.ecs_cluster.name
 }
+
+output "document_engine_endpoint" {
+  description = "Endpoint of the Document Engine service"
+  value = format(
+    "http://%s:80",
+    module.alb.dns_name
+  )
+}

--- a/document-engine/de-aws-ecs-terraform/outputs.tf
+++ b/document-engine/de-aws-ecs-terraform/outputs.tf
@@ -1,0 +1,34 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = module.cluster_vpc.vpc_id
+}
+
+output "cluster_subnet_cidrs" {
+  description = "List of CIDRs of the public subnets"
+  value       = local.cluster_subnets
+}
+
+output "public_subnet_ids" {
+  description = "List of IDs of the public subnets"
+  value       = module.cluster_vpc.public_subnets
+}
+
+output "private_subnet_ids" {
+  description = "List of IDs of the private subnets"
+  value       = module.cluster_vpc.private_subnets
+}
+
+output "cluster_id" {
+  description = "ID of the ECS cluster"
+  value       = module.ecs_cluster.id
+}
+
+output "cluster_arn" {
+  description = "ARN of the ECS cluster"
+  value       = module.ecs_cluster.arn
+}
+
+output "cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = module.ecs_cluster.name
+}

--- a/document-engine/de-aws-ecs-terraform/terraform.tfvars
+++ b/document-engine/de-aws-ecs-terraform/terraform.tfvars
@@ -10,12 +10,14 @@ document_engine_dashboard_username = "admin"
 document_engine_dashboard_password = "nutrientAdmin!"
 
 document_engine_parameters = {
-  image_tag     = "1.11.0"
-  logging_level = "info"
-  cpu           = 2048
-  memory        = 4096
-  desired_count = 2
-  port          = 5000
+  image_tag           = "1.11.0"
+  logging_level       = "info"
+  cpu                 = 2048
+  memory              = 4096
+  desired_count       = 2
+  port                = 5000
+  jwt_algorithm       = "RS256"
+  jwt_public_key_path = "./JWT_PUBLIC_KEY.pem"
   extra_env = {
     PSPDFKIT_WORKER_POOL_SIZE = "8"
   }

--- a/document-engine/de-aws-ecs-terraform/terraform.tfvars
+++ b/document-engine/de-aws-ecs-terraform/terraform.tfvars
@@ -1,0 +1,27 @@
+environment_name_prefix = "nutrient-demo"
+
+# Document Engine
+
+document_engine_activation_key = null
+document_engine_parameters = {
+  image_tag     = "1.11.0"
+  logging_level = "info"
+  cpu           = 2048
+  memory        = 4096
+  port          = 5000
+  extra_env = {
+    PSPDFKIT_WORKER_POOL_SIZE = "8"
+  }
+}
+
+# AWS
+
+aws_region = "eu-north-1"
+
+# Names and resources
+
+environment_name = "nutrient-de-demo"
+additional_tags = {
+  "nutrient:environment" = "nutrient-de-demo"
+  "nutrient:demo"        = "true"
+}

--- a/document-engine/de-aws-ecs-terraform/terraform.tfvars
+++ b/document-engine/de-aws-ecs-terraform/terraform.tfvars
@@ -3,11 +3,18 @@ environment_name_prefix = "nutrient-demo"
 # Document Engine
 
 document_engine_activation_key = null
+
+document_engine_api_auth_token = "whatever"
+
+document_engine_dashboard_username = "admin"
+document_engine_dashboard_password = "nutrientAdmin!"
+
 document_engine_parameters = {
   image_tag     = "1.11.0"
   logging_level = "info"
   cpu           = 2048
   memory        = 4096
+  desired_count = 2
   port          = 5000
   extra_env = {
     PSPDFKIT_WORKER_POOL_SIZE = "8"

--- a/document-engine/de-aws-ecs-terraform/utility.tf
+++ b/document-engine/de-aws-ecs-terraform/utility.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.31"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12"
+    }
+  }
+}
+
+provider "aws" {
+  profile = var.aws_profile_name
+  region  = var.aws_region
+
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  profile = var.aws_profile_name
+  region  = "us-east-1"
+  alias   = "virginia"
+
+  default_tags {
+    tags = var.tags
+  }
+}
+
+#
+# Data
+#
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_ecrpublic_authorization_token" "token" {
+  provider = aws.virginia
+}
+
+locals {
+  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  aws_region_name = data.aws_region.current.region
+  aws_account_id  = data.aws_caller_identity.current.account_id
+}

--- a/document-engine/de-aws-ecs-terraform/utility.tf
+++ b/document-engine/de-aws-ecs-terraform/utility.tf
@@ -22,7 +22,7 @@ provider "aws" {
   region  = var.aws_region
 
   default_tags {
-    tags = var.tags
+    tags = local.tags
   }
 }
 
@@ -32,7 +32,7 @@ provider "aws" {
   alias   = "virginia"
 
   default_tags {
-    tags = var.tags
+    tags = local.tags
   }
 }
 
@@ -50,6 +50,14 @@ data "aws_ecrpublic_authorization_token" "token" {
 }
 
 locals {
+  tags = merge(
+    {
+      MadeBy    = "Nutrient"
+      ManagedBy = "Terraform"
+    },
+    var.additional_tags
+  )
+
   azs             = slice(data.aws_availability_zones.available.names, 0, 3)
   aws_region_name = data.aws_region.current.region
   aws_account_id  = data.aws_caller_identity.current.account_id

--- a/document-engine/de-aws-ecs-terraform/variables.tf
+++ b/document-engine/de-aws-ecs-terraform/variables.tf
@@ -20,12 +20,31 @@ variable "document_engine_activation_key" {
   sensitive   = true
 }
 
+variable "document_engine_api_auth_token" {
+  description = "Document Engine auth token for the API"
+  type        = string
+  sensitive   = true
+}
+
+variable "document_engine_dashboard_username" {
+  description = "Document Engine dashboard username"
+  type        = string
+  sensitive   = true
+}
+
+variable "document_engine_dashboard_password" {
+  description = "Document Engine dashboard password"
+  type        = string
+  sensitive   = true
+}
+
 variable "document_engine_parameters" {
   description = "Document Engine parameters"
   type = object({
     image_tag     = string
     cpu           = number
     memory        = number
+    desired_count = number
     logging_level = string
     port          = number
     extra_env     = map(string)

--- a/document-engine/de-aws-ecs-terraform/variables.tf
+++ b/document-engine/de-aws-ecs-terraform/variables.tf
@@ -51,11 +51,8 @@ variable "log_retention_days" {
   default     = 7
 }
 
-variable "tags" {
+variable "additional_tags" {
   description = "A map of tags to assign to all resources"
   type        = map(string)
-  default = {
-    MadeBy    = "Nutrient"
-    ManagedBy = "Terraform"
-  }
+  default     = {}
 }

--- a/document-engine/de-aws-ecs-terraform/variables.tf
+++ b/document-engine/de-aws-ecs-terraform/variables.tf
@@ -41,13 +41,15 @@ variable "document_engine_dashboard_password" {
 variable "document_engine_parameters" {
   description = "Document Engine parameters"
   type = object({
-    image_tag     = string
-    cpu           = number
-    memory        = number
-    desired_count = number
-    logging_level = string
-    port          = number
-    extra_env     = map(string)
+    image_tag           = string
+    cpu                 = number
+    memory              = number
+    desired_count       = number
+    logging_level       = string
+    port                = number
+    jwt_algorithm       = string
+    jwt_public_key_path = string
+    extra_env           = map(string)
   })
 }
 

--- a/document-engine/de-aws-ecs-terraform/variables.tf
+++ b/document-engine/de-aws-ecs-terraform/variables.tf
@@ -1,0 +1,61 @@
+# AWS
+
+variable "aws_profile_name" {
+  type    = string
+  default = "default"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region"
+  default     = "eu-north-1"
+}
+
+# Document Engine
+
+variable "document_engine_activation_key" {
+  description = "Document Engine activation key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "document_engine_parameters" {
+  description = "Document Engine parameters"
+  type = object({
+    image_tag     = string
+    cpu           = number
+    memory        = number
+    logging_level = string
+    port          = number
+    extra_env     = map(string)
+  })
+}
+
+# ECS Infrastructure
+
+variable "environment_name" {
+  description = "Name of the ECS cluster, takes precedence over `environment_name_prefix` if set"
+  type        = string
+  default     = null
+}
+
+variable "environment_name_prefix" {
+  description = "Name prefix of the ECS cluster"
+  type        = string
+}
+
+variable "log_retention_days" {
+  description = "Retention period for CloudWatch logs in days"
+  type        = number
+  default     = 7
+}
+
+variable "tags" {
+  description = "A map of tags to assign to all resources"
+  type        = map(string)
+  default = {
+    MadeBy    = "Nutrient"
+    ManagedBy = "Terraform"
+  }
+}

--- a/document-engine/de-aws-ecs-terraform/vpc.tf
+++ b/document-engine/de-aws-ecs-terraform/vpc.tf
@@ -1,0 +1,44 @@
+#
+# https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
+# https://github.com/terraform-aws-modules/terraform-aws-vpc
+#
+locals {
+  vpc_cidr = "10.0.0.0/16"
+  cluster_subnets = {
+    private     = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 1)]
+    public      = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 11)]
+    intra       = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 21)]
+    database    = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 101)]
+    elasticache = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 201)]
+  }
+}
+
+module "cluster_vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "${local.environment_name}-vpc"
+
+  azs                             = local.azs
+  cidr                            = local.vpc_cidr
+  private_subnets                 = local.cluster_subnets.private
+  public_subnets                  = local.cluster_subnets.public
+  intra_subnets                   = local.cluster_subnets.intra
+  create_database_subnet_group    = true
+  database_subnets                = local.cluster_subnets.database
+  create_elasticache_subnet_group = false
+  elasticache_subnets             = local.cluster_subnets.elasticache
+
+  create_igw             = true
+  enable_nat_gateway     = true
+  single_nat_gateway     = true
+  one_nat_gateway_per_az = false
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  enable_flow_log = false
+
+  tags = {
+    Name = "${local.environment_name}-vpc"
+  }
+}


### PR DESCRIPTION
[SOUPOPS-4] A very simple ECS deployment example.

[SOUPOPS-4]: https://nutrient.atlassian.net/browse/SOUPOPS-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ