### PR TITLE
Kacper/UI customization updates

### DIFF
--- a/web/ui-customization-doc-editor-sidebar/package-lock.json
+++ b/web/ui-customization-doc-editor-sidebar/package-lock.json
@@ -8,10 +8,10 @@
       "name": "ui-customization-doc-editor-sidebar",
       "version": "0.0.0",
       "dependencies": {
-        "@baseline-ui/core": "^0.45.8",
-        "@baseline-ui/icons": "^0.45.8",
-        "@baseline-ui/tokens": "^0.45.8",
-        "@nutrient-sdk/viewer": "1.9.1",
+        "@baseline-ui/core": "^0.48.5",
+        "@baseline-ui/icons": "^0.48.5",
+        "@baseline-ui/tokens": "^0.48.5",
+        "@nutrient-sdk/viewer": "1.15.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -332,14 +332,14 @@
       }
     },
     "node_modules/@baseline-ui/core": {
-      "version": "0.45.8",
-      "resolved": "https://registry.npmjs.org/@baseline-ui/core/-/core-0.45.8.tgz",
-      "integrity": "sha512-f5m9OCFaXX4SsbcUeNUaiKt+sYUDQZ6H0HDPWGJIhZ86PVi9BcNZfBxAXHuTgK+uUBnb8xm+t6bsKhaOt1RvbA==",
+      "version": "0.48.6",
+      "resolved": "https://registry.npmjs.org/@baseline-ui/core/-/core-0.48.6.tgz",
+      "integrity": "sha512-uWgrkyx1bjKjg1NSwTov7Qr3j9PSb8jGxsWd6q4ViYB5q+yKQmT6D2U66qlhFpq4DPHZw21lDf2wqn/fkBh+5g==",
       "license": "SEE LICENSE IN https://pspdfkit.com/legal/License.pdf",
       "dependencies": {
-        "@baseline-ui/css": "0.45.8",
-        "@baseline-ui/icons": "0.45.8",
-        "@baseline-ui/tokens": "0.45.8",
+        "@baseline-ui/css": "0.48.6",
+        "@baseline-ui/icons": "0.48.6",
+        "@baseline-ui/tokens": "0.48.6",
         "@internationalized/date": "^3.8.2",
         "@udecode/cn": "^33.0.0",
         "@udecode/plate": "^44.0.1",
@@ -360,7 +360,6 @@
         "motion": "12.0.6",
         "perfect-freehand": "^1.2.2",
         "react-complex-tree": "^2.4.5",
-        "react-moveable": "^0.56.0",
         "react-resizable-panels": "2.0.23",
         "slate": "^0.112.0",
         "slate-history": "^0.110.3",
@@ -375,20 +374,20 @@
       }
     },
     "node_modules/@baseline-ui/css": {
-      "version": "0.45.8",
-      "resolved": "https://registry.npmjs.org/@baseline-ui/css/-/css-0.45.8.tgz",
-      "integrity": "sha512-3v9fiSwzHKaIC5tv/P5LFo6a6cTX43oOcYbT9iaZSVlpyanXEj/RtDZYu4IVNfkbBgQL3Oi4W8CrSrYlysnKLQ==",
+      "version": "0.48.6",
+      "resolved": "https://registry.npmjs.org/@baseline-ui/css/-/css-0.48.6.tgz",
+      "integrity": "sha512-d01u1uXo1qUKUYTOZpCUCcHuxpEQftl9imVLp9rp+Mlk0dpSPw2culIbqX3lo5tyV4iNGWKccJZntxI9VuVm1g==",
       "license": "SEE LICENSE IN https://pspdfkit.com/legal/License.pdf",
       "dependencies": {
-        "@baseline-ui/tokens": "0.45.8",
+        "@baseline-ui/tokens": "0.48.6",
         "@vanilla-extract/css": "1.17.4",
         "@vanilla-extract/recipes": "0.5.7"
       }
     },
     "node_modules/@baseline-ui/icons": {
-      "version": "0.45.8",
-      "resolved": "https://registry.npmjs.org/@baseline-ui/icons/-/icons-0.45.8.tgz",
-      "integrity": "sha512-FDAamscsCQ1BrxvRjdt/TPdb4RoUjLyz0f6Uyo+lRfaZSDYiAJPAV2HldRXatSTwo8m/Aw3TjPpI0iSHUl+CYw==",
+      "version": "0.48.6",
+      "resolved": "https://registry.npmjs.org/@baseline-ui/icons/-/icons-0.48.6.tgz",
+      "integrity": "sha512-Rstz7Bkjqw6CHKxqkLyu9zKKtgk+Zob4SfKAj7lflZu3M7iKsnmVh2p/+/NEJ69169hQy2QSNyN4vJVkEjqQ0w==",
       "license": "SEE LICENSE IN https://pspdfkit.com/legal/License.pdf",
       "dependencies": {
         "dompurify": "3.2.4"
@@ -399,57 +398,16 @@
       }
     },
     "node_modules/@baseline-ui/tokens": {
-      "version": "0.45.8",
-      "resolved": "https://registry.npmjs.org/@baseline-ui/tokens/-/tokens-0.45.8.tgz",
-      "integrity": "sha512-6KMlPzPF3FyMwGwtcFwKM0NE+TGHJkd30RTytq3bwV2hmc8scgFekAvnjQAeUYYSLZtVSf6HqVXhZFuH/uwHOg==",
+      "version": "0.48.6",
+      "resolved": "https://registry.npmjs.org/@baseline-ui/tokens/-/tokens-0.48.6.tgz",
+      "integrity": "sha512-LCCTng+nGSEleb4dllVwY6f2g6EyX+90NOIMEKHaZlomWpZ8P60cPwYX38ehQbBusVpl3CkitRedmmu4vJ1vEg==",
       "license": "SEE LICENSE IN https://pspdfkit.com/legal/License.pdf",
       "dependencies": {
         "lodash": "^4.2.1",
-        "zod": "^3.25.64",
-        "zod-validation-error": "^3.5.0"
+        "type-fest": "^5.2.0",
+        "zod": "^4.0.0",
+        "zod-validation-error": "^5.0.0"
       }
-    },
-    "node_modules/@cfcs/core": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@cfcs/core/-/core-0.0.6.tgz",
-      "integrity": "sha512-FxfJMwoLB8MEMConeXUCqtMGqxdtePQxRBOiGip9ULcYYam3WfCgoY6xdnMaSkYvRvmosp5iuG+TiPofm65+Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@egjs/component": "^3.0.2"
-      }
-    },
-    "node_modules/@daybrush/utils": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@daybrush/utils/-/utils-1.13.0.tgz",
-      "integrity": "sha512-ALK12C6SQNNHw1enXK+UO8bdyQ+jaWNQ1Af7Z3FNxeAwjYhQT7do+TRE4RASAJ3ObaS2+TJ7TXR3oz2Gzbw0PQ==",
-      "license": "MIT"
-    },
-    "node_modules/@egjs/agent": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@egjs/agent/-/agent-2.4.4.tgz",
-      "integrity": "sha512-cvAPSlUILhBBOakn2krdPnOGv5hAZq92f1YHxYcfu0p7uarix2C6Ia3AVizpS1SGRZGiEkIS5E+IVTLg1I2Iog==",
-      "license": "MIT"
-    },
-    "node_modules/@egjs/children-differ": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@egjs/children-differ/-/children-differ-1.0.1.tgz",
-      "integrity": "sha512-DRvyqMf+CPCOzAopQKHtW+X8iN6Hy6SFol+/7zCUiE5y4P/OB8JP8FtU4NxtZwtafvSL4faD5KoQYPj3JHzPFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@egjs/list-differ": "^1.0.0"
-      }
-    },
-    "node_modules/@egjs/component": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@egjs/component/-/component-3.0.5.tgz",
-      "integrity": "sha512-cLcGizTrrUNA2EYE3MBmEDt2tQv1joVP1Q3oDisZ5nw0MZDx2kcgEXM+/kZpfa/PAkFvYVhRUZwytIQWoN3V/w==",
-      "license": "MIT"
-    },
-    "node_modules/@egjs/list-differ": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@egjs/list-differ/-/list-differ-1.0.1.tgz",
-      "integrity": "sha512-OTFTDQcWS+1ZREOdCWuk5hCBgYO4OsD30lXcOCyVOAjXMhgL5rBRDnt/otb6Nz8CzU0L/igdcaQBDLWc4t9gvg==",
-      "license": "MIT"
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
@@ -1227,9 +1185,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.9.1.tgz",
-      "integrity": "sha512-QODpcjobRvbwBlHwcFN3yKqmXgzr04zFKbqTyRfyYFwun1JiXwE4z5zhep0QSxQlavFJvnwz0aABZBz5/LrkNg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.1.tgz",
+      "integrity": "sha512-VRj05CGGMoXZZbvWJSBBgYzYoCRdwOPne1IWFNr/l0hkyB5ijKoVh8m94O6w3Ru8cW0OnBv4VfjxJQK9Mci6Yg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"
@@ -1634,34 +1592,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@scena/dragscroll": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scena/dragscroll/-/dragscroll-1.4.0.tgz",
-      "integrity": "sha512-3O8daaZD9VXA9CP3dra6xcgt/qrm0mg0xJCwiX6druCteQ9FFsXffkF8PrqxY4Z4VJ58fFKEa0RlKqbsi/XnRA==",
-      "license": "MIT",
-      "dependencies": {
-        "@daybrush/utils": "^1.6.0",
-        "@scena/event-emitter": "^1.0.2"
-      }
-    },
-    "node_modules/@scena/event-emitter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@scena/event-emitter/-/event-emitter-1.0.5.tgz",
-      "integrity": "sha512-AzY4OTb0+7ynefmWFQ6hxDdk0CySAq/D4efljfhtRHCOP7MBF9zUfhKG3TJiroVjASqVgkRJFdenS8ArZo6Olg==",
-      "license": "MIT",
-      "dependencies": {
-        "@daybrush/utils": "^1.1.1"
-      }
-    },
-    "node_modules/@scena/matrix": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scena/matrix/-/matrix-1.1.1.tgz",
-      "integrity": "sha512-JVKBhN0tm2Srl+Yt+Ywqu0oLgLcdemDQlD1OxmN9jaCTwaFPZ7tY8n6dhVgMEaR9qcR7r+kAlMXnSfNyYdE+Vg==",
-      "license": "MIT",
-      "dependencies": {
-        "@daybrush/utils": "^1.4.0"
-      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.18",
@@ -2948,25 +2878,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-styled": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/css-styled/-/css-styled-1.0.8.tgz",
-      "integrity": "sha512-tCpP7kLRI8dI95rCh3Syl7I+v7PP+2JYOzWkl0bUEoSbJM+u8ITbutjlQVf0NC2/g4ULROJPi16sfwDIO8/84g==",
-      "license": "MIT",
-      "dependencies": {
-        "@daybrush/utils": "^1.13.0"
-      }
-    },
-    "node_modules/css-to-mat": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/css-to-mat/-/css-to-mat-1.1.1.tgz",
-      "integrity": "sha512-kvpxFYZb27jRd2vium35G7q5XZ2WJ9rWjDUMNT36M3Hc41qCrLXFM5iEKMGXcrPsKfXEN+8l/riB4QzwwwiEyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@daybrush/utils": "^1.13.0",
-        "@scena/matrix": "^1.0.0"
-      }
-    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -3016,9 +2927,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -3476,12 +3387,6 @@
         }
       }
     },
-    "node_modules/framework-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/framework-utils/-/framework-utils-1.1.0.tgz",
-      "integrity": "sha512-KAfqli5PwpFJ8o3psRNs8svpMGyCSAe8nmGcjQ0zZBWN2H6dZDnq+ABp3N3hdUmFeMrLtjOCTXD4yplUJIWceg==",
-      "license": "MIT"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3505,16 +3410,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/gesto": {
-      "version": "1.19.4",
-      "resolved": "https://registry.npmjs.org/gesto/-/gesto-1.19.4.tgz",
-      "integrity": "sha512-hfr/0dWwh0Bnbb88s3QVJd1ZRJeOWcgHPPwmiH6NnafDYvhTsxg+SLYu+q/oPNh9JS3V+nlr6fNs8kvPAtcRDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@daybrush/utils": "^1.13.0",
-        "@scena/event-emitter": "^1.0.2"
       }
     },
     "node_modules/glob-parent": {
@@ -3792,24 +3687,6 @@
       "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
       "license": "ISC"
     },
-    "node_modules/keycode": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
-      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg==",
-      "license": "MIT"
-    },
-    "node_modules/keycon": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/keycon/-/keycon-1.4.0.tgz",
-      "integrity": "sha512-p1NAIxiRMH3jYfTeXRs2uWbVJ1WpEjpi8ktzUyBJsX7/wn2qu2VRXktneBLNtKNxJmlUYxRi9gOJt1DuthXR7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@cfcs/core": "^0.0.6",
-        "@daybrush/utils": "^1.7.1",
-        "@scena/event-emitter": "^1.0.2",
-        "keycode": "^2.2.0"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4069,15 +3946,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/overlap-area": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/overlap-area/-/overlap-area-1.1.0.tgz",
-      "integrity": "sha512-3dlJgJCaVeXH0/eZjYVJvQiLVVrPO4U1ZGqlATtx6QGO3b5eNM6+JgUKa7oStBTdYuGTk7gVoABCW6Tp+dhRdw==",
-      "license": "MIT",
-      "dependencies": {
-        "@daybrush/utils": "^1.7.1"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4289,16 +4157,6 @@
         "react": ">=16.0.0"
       }
     },
-    "node_modules/react-css-styled": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/react-css-styled/-/react-css-styled-1.1.9.tgz",
-      "integrity": "sha512-M7fJZ3IWFaIHcZEkoFOnkjdiUFmwd8d+gTh2bpqMOcnxy/0Gsykw4dsL4QBiKsxcGow6tETUa4NAUcmJF+/nfw==",
-      "license": "MIT",
-      "dependencies": {
-        "css-styled": "~1.0.8",
-        "framework-utils": "^1.1.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
@@ -4327,27 +4185,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
-    "node_modules/react-moveable": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.56.0.tgz",
-      "integrity": "sha512-FmJNmIOsOA36mdxbrc/huiE4wuXSRlmon/o+/OrfNhSiYYYL0AV5oObtPluEhb2Yr/7EfYWBHTxF5aWAvjg1SA==",
-      "license": "MIT",
-      "dependencies": {
-        "@daybrush/utils": "^1.13.0",
-        "@egjs/agent": "^2.2.1",
-        "@egjs/children-differ": "^1.0.1",
-        "@egjs/list-differ": "^1.0.0",
-        "@scena/dragscroll": "^1.4.0",
-        "@scena/event-emitter": "^1.0.5",
-        "@scena/matrix": "^1.1.1",
-        "css-to-mat": "^1.1.1",
-        "framework-utils": "^1.1.0",
-        "gesto": "^1.19.3",
-        "overlap-area": "^1.1.0",
-        "react-css-styled": "^1.1.9",
-        "react-selecto": "^1.25.0"
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -4366,15 +4203,6 @@
       "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-selecto": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/react-selecto/-/react-selecto-1.26.3.tgz",
-      "integrity": "sha512-Ubik7kWSnZyQEBNro+1k38hZaI1tJarE+5aD/qsqCOA1uUBSjgKVBy3EWRzGIbdmVex7DcxznFZLec/6KZNvwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "selecto": "~1.26.3"
       }
     },
     "node_modules/react-tracked": {
@@ -4476,24 +4304,6 @@
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
       "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
       "license": "MIT"
-    },
-    "node_modules/selecto": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/selecto/-/selecto-1.26.3.tgz",
-      "integrity": "sha512-gZHgqMy5uyB6/2YDjv3Qqaf7bd2hTDOpPdxXlrez4R3/L0GiEWDCFaUfrflomgqdb3SxHF2IXY0Jw0EamZi7cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@daybrush/utils": "^1.13.0",
-        "@egjs/children-differ": "^1.0.1",
-        "@scena/dragscroll": "^1.4.0",
-        "@scena/event-emitter": "^1.0.5",
-        "css-styled": "^1.0.8",
-        "css-to-mat": "^1.1.1",
-        "framework-utils": "^1.1.0",
-        "gesto": "^1.19.4",
-        "keycon": "^1.2.0",
-        "overlap-area": "^1.1.0"
-      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -4644,6 +4454,18 @@
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
@@ -4713,6 +4535,21 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -4970,24 +4807,24 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-validation-error": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
-      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-5.0.0.tgz",
+      "integrity": "sha512-hmk+pkyKq7Q71PiWVSDUc3VfpzpvcRHZ3QPw9yEMVvmtCekaMeOHnbr3WbxfrgEnQTv6haGP4cmv0Ojmihzsxw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "zod": "^3.24.4"
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/web/ui-customization-doc-editor-sidebar/package.json
+++ b/web/ui-customization-doc-editor-sidebar/package.json
@@ -13,7 +13,7 @@
     "@baseline-ui/core": "^0.48.5",
     "@baseline-ui/icons": "^0.48.5",
     "@baseline-ui/tokens": "^0.48.5",
-    "@nutrient-sdk/viewer": "1.9.1",
+    "@nutrient-sdk/viewer": "1.15.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/web/ui-customization-doc-editor-sidebar/pnpm-lock.yaml
+++ b/web/ui-customization-doc-editor-sidebar/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.48.5
         version: 0.48.5
       '@nutrient-sdk/viewer':
-        specifier: 1.9.1
-        version: 1.9.1
+        specifier: 1.15.1
+        version: 1.15.1
       react:
         specifier: ^19.1.1
         version: 19.2.0
@@ -442,8 +442,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nutrient-sdk/viewer@1.9.1':
-    resolution: {integrity: sha512-QODpcjobRvbwBlHwcFN3yKqmXgzr04zFKbqTyRfyYFwun1JiXwE4z5zhep0QSxQlavFJvnwz0aABZBz5/LrkNg==}
+  '@nutrient-sdk/viewer@1.15.1':
+    resolution: {integrity: sha512-VRj05CGGMoXZZbvWJSBBgYzYoCRdwOPne1IWFNr/l0hkyB5ijKoVh8m94O6w3Ru8cW0OnBv4VfjxJQK9Mci6Yg==}
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -2213,7 +2213,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nutrient-sdk/viewer@1.9.1':
+  '@nutrient-sdk/viewer@1.15.1':
     dependencies:
       '@types/react': 18.3.26
 

--- a/web/ui-customization-doc-editor-sidebar/src/App.tsx
+++ b/web/ui-customization-doc-editor-sidebar/src/App.tsx
@@ -4,6 +4,10 @@ import { createRoot } from "react-dom/client";
 import "./App.css";
 import DocumentEditor from "./DocumentEditor";
 
+// Identifier for the custom sidebar slot. The same value is used as the
+// `sidebarMode` view state to open/close the sidebar.
+const SIDEBAR_ID = "customDocumentEditorSidebar";
+
 function App() {
   const containerRef = useRef(null);
 
@@ -30,13 +34,15 @@ function App() {
           styleSheets: [`${baseUrl}document-editor.css`],
           ui: {
             sidebar: {
-              documentEditor: (instance) => {
+              [SIDEBAR_ID]: (getInstance) => {
                 const container = document.createElement("div");
                 const root = createRoot(container);
 
                 return {
                   render: () => container,
                   onMount: () => {
+                    const instance = getInstance();
+
                     if (instance) {
                       root.render(<DocumentEditor instance={instance} />);
                     }
@@ -53,6 +59,12 @@ function App() {
             viewState.set("sidebarWidth", 600),
           );
 
+          // Custom sidebar identifiers are valid `sidebarMode` values at
+          // runtime, but the published `sidebarMode` type only lists the
+          // built-in modes. Cast our custom id so TypeScript accepts it.
+          const customSidebarMode =
+            SIDEBAR_ID as unknown as typeof instance.viewState.sidebarMode;
+
           function getDocumentEditorToolbarItem(isSelected: boolean) {
             return {
               type: "custom" as const,
@@ -65,9 +77,9 @@ function App() {
                 instance.setViewState((viewState) =>
                   viewState.set(
                     "sidebarMode",
-                    viewState.sidebarMode === "documentEditor"
+                    viewState.sidebarMode === customSidebarMode
                       ? null
-                      : "documentEditor",
+                      : customSidebarMode,
                   ),
                 );
               },
@@ -78,7 +90,7 @@ function App() {
           instance.setToolbarItems([
             ...NutrientViewer.defaultToolbarItems,
             getDocumentEditorToolbarItem(
-              instance.viewState.sidebarMode === "documentEditor",
+              instance.viewState.sidebarMode === customSidebarMode,
             ),
           ]);
 
@@ -86,7 +98,7 @@ function App() {
             instance.setToolbarItems([
               ...NutrientViewer.defaultToolbarItems,
               getDocumentEditorToolbarItem(
-                viewState.sidebarMode === "documentEditor",
+                viewState.sidebarMode === customSidebarMode,
               ),
             ]);
           });

--- a/web/ui-customization-doc-editor-sidebar/src/DocumentEditor.tsx
+++ b/web/ui-customization-doc-editor-sidebar/src/DocumentEditor.tsx
@@ -359,12 +359,12 @@ const DocumentEditor = (props: Props) => {
         });
 
         const importOperation: DocumentOperations.ImportDocumentAfterOperation =
-          {
-            type: "importDocument",
-            afterPageIndex: afterIndex,
-            document: copiedFile,
-            treatImportedDocumentAsOnePage: true,
-          };
+        {
+          type: "importDocument",
+          afterPageIndex: afterIndex,
+          document: copiedFile,
+          treatImportedDocumentAsOnePage: true,
+        };
 
         // Add a placeholder draft page for the imported document
         setDraftPages((current) => {

--- a/web/ui-customization-doc-editor-sidebar/src/DocumentEditor.tsx
+++ b/web/ui-customization-doc-editor-sidebar/src/DocumentEditor.tsx
@@ -309,11 +309,13 @@ const DocumentEditor = (props: Props) => {
       // Move each selected page one slot to the left with its own operation.
       // A single backward `movePages` with `beforePageIndex` can diverge from
       // the expected result for multi-page selections.
-      const operations: DocumentOperation[] = sortedIndexes.map((pageIndex) => ({
-        type: "movePages",
-        pageIndexes: [pageIndex],
-        beforePageIndex: pageIndex - 1,
-      }));
+      const operations: DocumentOperation[] = sortedIndexes.map(
+        (pageIndex) => ({
+          type: "movePages",
+          pageIndexes: [pageIndex],
+          beforePageIndex: pageIndex - 1,
+        }),
+      );
 
       setOperationQueue((prev) => [...prev, ...operations]);
       setIsUnsavedTagDismissed(false);
@@ -359,12 +361,12 @@ const DocumentEditor = (props: Props) => {
         });
 
         const importOperation: DocumentOperations.ImportDocumentAfterOperation =
-        {
-          type: "importDocument",
-          afterPageIndex: afterIndex,
-          document: copiedFile,
-          treatImportedDocumentAsOnePage: true,
-        };
+          {
+            type: "importDocument",
+            afterPageIndex: afterIndex,
+            document: copiedFile,
+            treatImportedDocumentAsOnePage: true,
+          };
 
         // Add a placeholder draft page for the imported document
         setDraftPages((current) => {
@@ -535,8 +537,7 @@ const DocumentEditor = (props: Props) => {
   // Don't allow removing every page — the document must keep at least one.
   const isRemoveDisabled =
     isOperationsDisabled ||
-    (draftPages.length > 0 &&
-      selectedPageIndexes.length === draftPages.length);
+    (draftPages.length > 0 && selectedPageIndexes.length === draftPages.length);
   // Disable the move buttons when the selection is already at the edge.
   const canMoveLeft =
     selectedPageIndexes.length > 0 && !selectedPageIndexes.includes(0);

--- a/web/ui-customization-doc-editor-sidebar/src/DocumentEditor.tsx
+++ b/web/ui-customization-doc-editor-sidebar/src/DocumentEditor.tsx
@@ -45,6 +45,8 @@ interface DraftPageData {
   pageIndex: number;
   src: string;
   rotation: number;
+  width: number;
+  height: number;
 
   draftRotation?: number; // Additional rotation applied in draft state
   isNew?: boolean;
@@ -68,6 +70,9 @@ const DocumentEditor = (props: Props) => {
   const [operationQueue, setOperationQueue] = useState<DocumentOperation[]>([]);
   const [isUnsavedTagDismissed, setIsUnsavedTagDismissed] = useState(false);
   const blobUrlsRef = useRef<Set<string>>(new Set());
+  // Monotonic counter so temporary (added/duplicated/imported) pages always get
+  // unique IDs, even when created within the same millisecond.
+  const temporaryPageCounterRef = useRef(0);
 
   const cleanupBlobUrls = useCallback(() => {
     blobUrlsRef.current.forEach((url) => {
@@ -100,12 +105,16 @@ const DocumentEditor = (props: Props) => {
       }
 
       pagesData.push({
-        id: pageInfo.label,
+        // Page labels aren't guaranteed to be unique, so build a stable ID from
+        // the page index and label instead of using the label alone.
+        id: `page-${pageInfo.index}-${pageInfo.label}`,
         label: pageInfo.label,
         alt: pageInfo.label,
         pageIndex: pageInfo.index,
         src,
         rotation: pageInfo.rotation || 0,
+        width: pageInfo.width,
+        height: pageInfo.height,
       });
     }
 
@@ -182,24 +191,37 @@ const DocumentEditor = (props: Props) => {
       });
     } else if (operation === "add-page") {
       const selectedPageIndexes = getPageIndexesFromSelectedKeys();
-      const afterIndex = selectedPageIndexes[0];
+      // Add can be used without a selection — append the new page at the end in
+      // that case. Otherwise insert it after the selected page.
+      const afterIndex =
+        selectedPageIndexes.length === 1
+          ? selectedPageIndexes[0]
+          : Math.max(draftPages.length - 1, 0);
+      // Match the new page size to a reference page instead of hardcoding it.
+      const referencePage = draftPages[afterIndex] ?? draftPages[0];
+      const pageWidth = referencePage?.width ?? 595;
+      const pageHeight = referencePage?.height ?? 842;
+
       operationData = {
         type: "addPage",
         afterPageIndex: afterIndex,
         backgroundColor: new NutrientViewer.Color({ r: 255, g: 255, b: 255 }),
-        pageHeight: 400,
-        pageWidth: 300,
+        pageHeight,
+        pageWidth,
         rotateBy: 0,
       };
 
       setDraftPages((current) => {
+        temporaryPageCounterRef.current += 1;
         const newPage: DraftPageData = {
-          id: `temp-${Date.now()}`,
+          id: `temp-${Date.now()}-${temporaryPageCounterRef.current}`,
           label: "New Page",
           alt: "New blank page",
           pageIndex: afterIndex + 1,
           src: "",
           rotation: 0,
+          width: pageWidth,
+          height: pageHeight,
           isNew: true,
         };
         const result = [
@@ -224,9 +246,10 @@ const DocumentEditor = (props: Props) => {
         for (const pageIndex of selectedPageIndexes) {
           const originalPage = result.find((p) => p.pageIndex === pageIndex);
           if (originalPage) {
+            temporaryPageCounterRef.current += 1;
             const duplicatedPage: DraftPageData = {
               ...originalPage,
-              id: `temp-dup-${Date.now()}-${pageIndex}`,
+              id: `temp-dup-${Date.now()}-${temporaryPageCounterRef.current}`,
               label: `${originalPage.label} (copy)`,
               alt: `${originalPage.alt} (copy)`,
             };
@@ -274,38 +297,42 @@ const DocumentEditor = (props: Props) => {
         return updatePageIndexes(result);
       });
     } else if (operation === "move-left") {
-      const selectedPageIndexes = getPageIndexesFromSelectedKeys().sort(
+      const sortedIndexes = getPageIndexesFromSelectedKeys().sort(
         (a, b) => a - b,
       );
 
       // Can't move left if the leftmost selected page is already at the start
-      const minIndex = Math.min(...selectedPageIndexes);
-      if (minIndex === 0) {
+      if (sortedIndexes.length === 0 || sortedIndexes[0] === 0) {
         return;
       }
 
-      operationData = {
+      // Move each selected page one slot to the left with its own operation.
+      // A single backward `movePages` with `beforePageIndex` can diverge from
+      // the expected result for multi-page selections.
+      const operations: DocumentOperation[] = sortedIndexes.map((pageIndex) => ({
         type: "movePages",
-        pageIndexes: selectedPageIndexes,
-        beforePageIndex: minIndex - 1,
-      };
+        pageIndexes: [pageIndex],
+        beforePageIndex: pageIndex - 1,
+      }));
+
+      setOperationQueue((prev) => [...prev, ...operations]);
+      setIsUnsavedTagDismissed(false);
 
       setDraftPages((current) => {
-        const pagesToMove = selectedPageIndexes.map((index) => current[index]);
-        const remaining = current.filter(
-          (_, index) => !selectedPageIndexes.includes(index),
-        );
+        const result = [...current];
 
-        // Insert all pages before minIndex position (adjust for removed pages)
-        const insertPosition = minIndex - 1;
-        const result = [
-          ...remaining.slice(0, insertPosition),
-          ...pagesToMove,
-          ...remaining.slice(insertPosition),
-        ];
+        for (const pageIndex of sortedIndexes) {
+          const page = result[pageIndex];
+          if (page) {
+            result.splice(pageIndex, 1);
+            result.splice(pageIndex - 1, 0, page);
+          }
+        }
 
         return updatePageIndexes(result);
       });
+
+      return; // Operations already queued above.
     } else if (operation === "import-document") {
       // Create file input
       const input = document.createElement("input");
@@ -320,25 +347,37 @@ const DocumentEditor = (props: Props) => {
         const afterIndex =
           selectedPageIndexes.length > 0
             ? Math.max(...selectedPageIndexes)
-            : draftPages.length - 1;
+            : Math.max(draftPages.length - 1, 0);
+
+        // Copy the uploaded file into a fresh `File` so the import operation
+        // doesn't rely on the original file handle, which the browser can
+        // invalidate before the operation runs.
+        const arrayBuffer = await file.arrayBuffer();
+        const copiedFile = new File([arrayBuffer], file.name, {
+          type: file.type,
+          lastModified: file.lastModified,
+        });
 
         const importOperation: DocumentOperations.ImportDocumentAfterOperation =
           {
             type: "importDocument",
             afterPageIndex: afterIndex,
-            document: file,
+            document: copiedFile,
             treatImportedDocumentAsOnePage: true,
           };
 
         // Add a placeholder draft page for the imported document
         setDraftPages((current) => {
+          temporaryPageCounterRef.current += 1;
           const newPage: DraftPageData = {
-            id: `temp-import-${Date.now()}`,
+            id: `temp-import-${Date.now()}-${temporaryPageCounterRef.current}`,
             label: file.name,
             alt: `Imported: ${file.name}`,
             pageIndex: afterIndex + 1,
             src: "", // Will be populated after save
             rotation: 0,
+            width: 595,
+            height: 842,
             isNew: true,
           };
           const result = [
@@ -492,6 +531,18 @@ const DocumentEditor = (props: Props) => {
   };
 
   const isOperationsDisabled = selectedKeys.size === 0;
+  const selectedPageIndexes = getPageIndexesFromSelectedKeys();
+  // Don't allow removing every page — the document must keep at least one.
+  const isRemoveDisabled =
+    isOperationsDisabled ||
+    (draftPages.length > 0 &&
+      selectedPageIndexes.length === draftPages.length);
+  // Disable the move buttons when the selection is already at the edge.
+  const canMoveLeft =
+    selectedPageIndexes.length > 0 && !selectedPageIndexes.includes(0);
+  const canMoveRight =
+    selectedPageIndexes.length > 0 &&
+    !selectedPageIndexes.includes(draftPages.length - 1);
 
   return (
     <ThemeProvider theme={themes.base.light}>
@@ -593,7 +644,7 @@ const DocumentEditor = (props: Props) => {
                     aria-label="Delete Page"
                     tooltip
                     size="lg"
-                    isDisabled={isOperationsDisabled}
+                    isDisabled={isRemoveDisabled}
                     onPress={() => queueDocumentOperation("remove-pages")}
                   />
                   <ActionIconButton
@@ -602,7 +653,6 @@ const DocumentEditor = (props: Props) => {
                     aria-label="Add Page"
                     tooltip
                     size="lg"
-                    isDisabled={isOperationsDisabled}
                     onPress={() => queueDocumentOperation("add-page")}
                   />
                   <ActionIconButton
@@ -628,7 +678,7 @@ const DocumentEditor = (props: Props) => {
                     aria-label="Move Left"
                     tooltip
                     size="lg"
-                    isDisabled={isOperationsDisabled}
+                    isDisabled={!canMoveLeft}
                     onPress={() => queueDocumentOperation("move-left")}
                   />
                   <ActionIconButton
@@ -637,7 +687,7 @@ const DocumentEditor = (props: Props) => {
                     aria-label="Move Right"
                     tooltip
                     size="lg"
-                    isDisabled={isOperationsDisabled}
+                    isDisabled={!canMoveRight}
                     onPress={() => queueDocumentOperation("move-right")}
                   />
                   <ActionIconButton

--- a/web/ui-customization/package-lock.json
+++ b/web/ui-customization/package-lock.json
@@ -11,7 +11,7 @@
         "@baseline-ui/core": "^0.45.8",
         "@baseline-ui/icons": "^0.45.8",
         "@baseline-ui/tokens": "^0.45.8",
-        "@nutrient-sdk/viewer": "1.9.1",
+        "@nutrient-sdk/viewer": "1.15.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -20,14 +20,14 @@
         "@types/node": "^24.6.0",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
-        "@vitejs/plugin-react": "^5.0.4",
+        "@vitejs/plugin-react": "^5.1.2",
         "eslint": "^9.36.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.22",
         "globals": "^16.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.45.0",
-        "vite": "^7.1.7"
+        "vite": "^7.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1227,9 +1227,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.9.1.tgz",
-      "integrity": "sha512-QODpcjobRvbwBlHwcFN3yKqmXgzr04zFKbqTyRfyYFwun1JiXwE4z5zhep0QSxQlavFJvnwz0aABZBz5/LrkNg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.1.tgz",
+      "integrity": "sha512-VRj05CGGMoXZZbvWJSBBgYzYoCRdwOPne1IWFNr/l0hkyB5ijKoVh8m94O6w3Ru8cW0OnBv4VfjxJQK9Mci6Yg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/web/ui-customization/package.json
+++ b/web/ui-customization/package.json
@@ -13,7 +13,7 @@
     "@baseline-ui/core": "^0.45.8",
     "@baseline-ui/icons": "^0.45.8",
     "@baseline-ui/tokens": "^0.45.8",
-    "@nutrient-sdk/viewer": "1.9.1",
+    "@nutrient-sdk/viewer": "1.15.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/web/ui-customization/pnpm-lock.yaml
+++ b/web/ui-customization/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
     dependencies:
       '@baseline-ui/core':
         specifier: ^0.45.8
-        version: 0.45.8(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-dom@0.112.2(slate@0.112.0))
+        version: 0.45.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-dom@0.112.2(slate@0.112.0))
       '@baseline-ui/icons':
         specifier: ^0.45.8
         version: 0.45.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.45.8
         version: 0.45.8
       '@nutrient-sdk/viewer':
-        specifier: 1.9.1
-        version: 1.9.1
+        specifier: 1.15.1
+        version: 1.15.1
       react:
         specifier: ^19.1.1
         version: 19.2.0
@@ -43,8 +43,8 @@ importers:
         specifier: ^19.1.9
         version: 19.2.2(@types/react@19.2.2)
       '@vitejs/plugin-react':
-        specifier: ^5.0.4
-        version: 5.1.0(vite@7.1.12(@types/node@24.9.2))
+        specifier: ^5.1.2
+        version: 5.2.0(vite@7.3.5(@types/node@24.9.2))
       eslint:
         specifier: ^9.36.0
         version: 9.38.0
@@ -64,41 +64,41 @@ importers:
         specifier: ^8.45.0
         version: 8.46.2(eslint@9.38.0)(typescript@5.9.3)
       vite:
-        specifier: ^7.1.7
-        version: 7.1.12(@types/node@24.9.2)
+        specifier: ^7.3.1
+        version: 7.3.5(@types/node@24.9.2)
 
 packages:
 
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.5':
-    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.28.5':
-    resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -111,20 +111,33 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.4':
-    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -144,16 +157,20 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.5':
-    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@baseline-ui/core@0.45.8':
@@ -195,158 +212,158 @@ packages:
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
 
-  '@esbuild/aix-ppc64@0.25.11':
-    resolution: {integrity: sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==}
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.11':
-    resolution: {integrity: sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==}
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.11':
-    resolution: {integrity: sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==}
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.11':
-    resolution: {integrity: sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==}
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.11':
-    resolution: {integrity: sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==}
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.11':
-    resolution: {integrity: sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==}
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.11':
-    resolution: {integrity: sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==}
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.11':
-    resolution: {integrity: sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==}
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.11':
-    resolution: {integrity: sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==}
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.11':
-    resolution: {integrity: sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==}
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.11':
-    resolution: {integrity: sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==}
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.11':
-    resolution: {integrity: sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==}
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.11':
-    resolution: {integrity: sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==}
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.11':
-    resolution: {integrity: sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==}
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.11':
-    resolution: {integrity: sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==}
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.11':
-    resolution: {integrity: sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==}
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.11':
-    resolution: {integrity: sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==}
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.11':
-    resolution: {integrity: sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==}
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.11':
-    resolution: {integrity: sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==}
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.11':
-    resolution: {integrity: sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==}
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.11':
-    resolution: {integrity: sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==}
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.11':
-    resolution: {integrity: sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==}
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.11':
-    resolution: {integrity: sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==}
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.11':
-    resolution: {integrity: sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==}
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.11':
-    resolution: {integrity: sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==}
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.11':
-    resolution: {integrity: sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==}
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -460,8 +477,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nutrient-sdk/viewer@1.9.1':
-    resolution: {integrity: sha512-QODpcjobRvbwBlHwcFN3yKqmXgzr04zFKbqTyRfyYFwun1JiXwE4z5zhep0QSxQlavFJvnwz0aABZBz5/LrkNg==}
+  '@nutrient-sdk/viewer@1.15.1':
+    resolution: {integrity: sha512-VRj05CGGMoXZZbvWJSBBgYzYoCRdwOPne1IWFNr/l0hkyB5ijKoVh8m94O6w3Ru8cW0OnBv4VfjxJQK9Mci6Yg==}
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -481,8 +498,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.43':
-    resolution: {integrity: sha512-5Uxg7fQUCmfhax7FJke2+8B6cqgeUJUD9o2uXIKXhD+mG0mL6NObmVoi9wXEU1tY89mZKgAYA6fTbftx3q2ZPQ==}
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
   '@rollup/rollup-android-arm-eabi@4.52.5':
     resolution: {integrity: sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==}
@@ -898,11 +915,11 @@ packages:
     peerDependencies:
       '@vanilla-extract/css': ^1.0.0
 
-  '@vitejs/plugin-react@5.1.0':
-    resolution: {integrity: sha512-4LuWrg7EKWgQaMJfnN+wcmbAW+VSsCmqGohftWjuct47bv8uE4n/nPpq4XjJPsxgq00GGG5J8dvBczp8uxScew==}
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1066,8 +1083,8 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
-  esbuild@0.25.11:
-    resolution: {integrity: sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==}
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1776,8 +1793,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  vite@7.1.12:
-    resolution: {integrity: sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1886,25 +1903,25 @@ packages:
 
 snapshots:
 
-  '@babel/code-frame@7.27.1':
+  '@babel/code-frame@7.29.7':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.5': {}
+  '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.28.5':
+  '@babel/core@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -1914,37 +1931,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.28.5':
+  '@babel/generator@7.29.7':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.27.2':
+  '@babel/helper-compilation-targets@7.29.7':
     dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
       browserslist: 4.27.0
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-globals@7.28.0': {}
+  '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.27.1':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -1952,45 +1969,53 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/helper-validator-option@7.27.1': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helpers@7.28.4':
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.28.4': {}
 
-  '@babel/template@7.27.2':
+  '@babel/template@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
-  '@babel/traverse@7.28.5':
+  '@babel/traverse@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -2000,7 +2025,12 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@baseline-ui/core@0.45.8(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-dom@0.112.2(slate@0.112.0))':
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@baseline-ui/core@0.45.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-dom@0.112.2(slate@0.112.0))':
     dependencies:
       '@baseline-ui/css': 0.45.8
       '@baseline-ui/icons': 0.45.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -2008,12 +2038,12 @@ snapshots:
       '@internationalized/date': 3.10.0
       '@udecode/cn': 33.0.0(@types/react@19.2.2)(class-variance-authority@0.7.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwind-merge@2.6.0)
       '@udecode/plate': 44.0.7(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0)(use-sync-external-store@1.4.0(react@19.2.0))
-      '@udecode/plate-basic-marks': 36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
-      '@udecode/plate-combobox': 36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
-      '@udecode/plate-common': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
-      '@udecode/plate-font': 36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
-      '@udecode/plate-link': 36.5.9(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
-      '@udecode/plate-paragraph': 36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-basic-marks': 36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-combobox': 36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-common': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-font': 36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-link': 36.5.9(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-paragraph': 36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
       '@vanilla-extract/dynamic': 2.1.5
       class-variance-authority: 0.7.1
       comlink: 4.4.2
@@ -2084,82 +2114,82 @@ snapshots:
 
   '@emotion/hash@0.9.2': {}
 
-  '@esbuild/aix-ppc64@0.25.11':
+  '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/android-arm64@0.25.11':
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
-  '@esbuild/android-arm@0.25.11':
+  '@esbuild/android-arm@0.27.7':
     optional: true
 
-  '@esbuild/android-x64@0.25.11':
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.11':
+  '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.11':
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.11':
+  '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.11':
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.11':
+  '@esbuild/linux-arm64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm@0.25.11':
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.11':
+  '@esbuild/linux-ia32@0.27.7':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.11':
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.11':
+  '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.11':
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.11':
+  '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.11':
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
-  '@esbuild/linux-x64@0.25.11':
+  '@esbuild/linux-x64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.11':
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.11':
+  '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.11':
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.11':
+  '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.11':
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.11':
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.11':
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.11':
+  '@esbuild/win32-ia32@0.27.7':
     optional: true
 
-  '@esbuild/win32-x64@0.25.11':
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0)':
@@ -2281,7 +2311,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nutrient-sdk/viewer@1.9.1':
+  '@nutrient-sdk/viewer@1.15.1':
     dependencies:
       '@types/react': 18.3.26
 
@@ -2298,7 +2328,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
-  '@rolldown/pluginutils@1.0.0-beta.43': {}
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.52.5':
     optional: true
@@ -2533,9 +2563,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@udecode/plate-basic-marks@36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
+  '@udecode/plate-basic-marks@36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
     dependencies:
-      '@udecode/plate-common': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-common': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       slate: 0.112.0
@@ -2543,9 +2573,9 @@ snapshots:
       slate-hyperscript: 0.100.0(slate@0.112.0)
       slate-react: 0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0)
 
-  '@udecode/plate-combobox@36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
+  '@udecode/plate-combobox@36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
     dependencies:
-      '@udecode/plate-common': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-common': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
       downshift: 6.1.12(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -2554,10 +2584,10 @@ snapshots:
       slate-hyperscript: 0.100.0(slate@0.112.0)
       slate-react: 0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0)
 
-  '@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
+  '@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
     dependencies:
-      '@udecode/plate-core': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
-      '@udecode/plate-utils': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-core': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-utils': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
       '@udecode/react-utils': 33.0.0(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@udecode/slate': 36.0.6(slate-history@0.110.3(slate@0.112.0))(slate@0.112.0)
       '@udecode/slate-react': 36.0.6(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
@@ -2577,7 +2607,7 @@ snapshots:
       - react-native
       - scheduler
 
-  '@udecode/plate-core@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
+  '@udecode/plate-core@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
     dependencies:
       '@udecode/slate': 36.0.6(slate-history@0.110.3(slate@0.112.0))(slate@0.112.0)
       '@udecode/slate-react': 36.0.6(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
@@ -2585,9 +2615,9 @@ snapshots:
       '@udecode/utils': 31.0.0
       clsx: 1.2.1
       is-hotkey: 0.2.0
-      jotai: 2.15.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0)
-      jotai-optics: 0.3.2(jotai@2.15.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0))(optics-ts@2.4.1)
-      jotai-x: 1.2.4(@types/react@19.2.2)(jotai@2.15.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)
+      jotai: 2.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(react@19.2.0)
+      jotai-optics: 0.3.2(jotai@2.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(react@19.2.0))(optics-ts@2.4.1)
+      jotai-x: 1.2.4(@types/react@19.2.2)(jotai@2.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)
       lodash: 4.17.21
       nanoid: 3.3.11
       optics-ts: 2.4.1
@@ -2640,11 +2670,11 @@ snapshots:
       - slate-dom
       - use-sync-external-store
 
-  '@udecode/plate-floating@36.3.8(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
+  '@udecode/plate-floating@36.3.8(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
     dependencies:
       '@floating-ui/core': 1.7.3
       '@floating-ui/react': 0.22.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@udecode/plate-common': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-common': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       slate: 0.112.0
@@ -2652,9 +2682,9 @@ snapshots:
       slate-hyperscript: 0.100.0(slate@0.112.0)
       slate-react: 0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0)
 
-  '@udecode/plate-font@36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
+  '@udecode/plate-font@36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
     dependencies:
-      '@udecode/plate-common': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-common': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
       lodash: 4.17.21
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -2663,11 +2693,11 @@ snapshots:
       slate-hyperscript: 0.100.0(slate@0.112.0)
       slate-react: 0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0)
 
-  '@udecode/plate-link@36.5.9(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
+  '@udecode/plate-link@36.5.9(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
     dependencies:
-      '@udecode/plate-common': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
-      '@udecode/plate-floating': 36.3.8(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
-      '@udecode/plate-normalizers': 36.5.6(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-common': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-floating': 36.3.8(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-normalizers': 36.5.6(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       slate: 0.112.0
@@ -2675,9 +2705,9 @@ snapshots:
       slate-hyperscript: 0.100.0(slate@0.112.0)
       slate-react: 0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0)
 
-  '@udecode/plate-normalizers@36.5.6(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
+  '@udecode/plate-normalizers@36.5.6(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
     dependencies:
-      '@udecode/plate-common': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-common': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
       lodash: 4.17.21
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -2686,9 +2716,9 @@ snapshots:
       slate-hyperscript: 0.100.0(slate@0.112.0)
       slate-react: 0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0)
 
-  '@udecode/plate-paragraph@36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
+  '@udecode/plate-paragraph@36.0.0(@udecode/plate-common@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
     dependencies:
-      '@udecode/plate-common': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-common': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       slate: 0.112.0
@@ -2696,9 +2726,9 @@ snapshots:
       slate-hyperscript: 0.100.0(slate@0.112.0)
       slate-react: 0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0)
 
-  '@udecode/plate-utils@36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
+  '@udecode/plate-utils@36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)':
     dependencies:
-      '@udecode/plate-core': 36.5.9(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
+      '@udecode/plate-core': 36.5.9(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(immer@10.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(scheduler@0.27.0)(slate-history@0.110.3(slate@0.112.0))(slate-hyperscript@0.100.0(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
       '@udecode/react-utils': 33.0.0(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@udecode/slate': 36.0.6(slate-history@0.110.3(slate@0.112.0))(slate@0.112.0)
       '@udecode/slate-react': 36.0.6(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-history@0.110.3(slate@0.112.0))(slate-react@0.112.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.112.2(slate@0.112.0))(slate@0.112.0))(slate@0.112.0)
@@ -2849,15 +2879,15 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.17.4
 
-  '@vitejs/plugin-react@5.1.0(vite@7.1.12(@types/node@24.9.2))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@24.9.2))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
-      '@rolldown/pluginutils': 1.0.0-beta.43
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.1.12(@types/node@24.9.2)
+      vite: 7.3.5(@types/node@24.9.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -2996,34 +3026,34 @@ snapshots:
 
   entities@4.5.0: {}
 
-  esbuild@0.25.11:
+  esbuild@0.27.7:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.11
-      '@esbuild/android-arm': 0.25.11
-      '@esbuild/android-arm64': 0.25.11
-      '@esbuild/android-x64': 0.25.11
-      '@esbuild/darwin-arm64': 0.25.11
-      '@esbuild/darwin-x64': 0.25.11
-      '@esbuild/freebsd-arm64': 0.25.11
-      '@esbuild/freebsd-x64': 0.25.11
-      '@esbuild/linux-arm': 0.25.11
-      '@esbuild/linux-arm64': 0.25.11
-      '@esbuild/linux-ia32': 0.25.11
-      '@esbuild/linux-loong64': 0.25.11
-      '@esbuild/linux-mips64el': 0.25.11
-      '@esbuild/linux-ppc64': 0.25.11
-      '@esbuild/linux-riscv64': 0.25.11
-      '@esbuild/linux-s390x': 0.25.11
-      '@esbuild/linux-x64': 0.25.11
-      '@esbuild/netbsd-arm64': 0.25.11
-      '@esbuild/netbsd-x64': 0.25.11
-      '@esbuild/openbsd-arm64': 0.25.11
-      '@esbuild/openbsd-x64': 0.25.11
-      '@esbuild/openharmony-arm64': 0.25.11
-      '@esbuild/sunos-x64': 0.25.11
-      '@esbuild/win32-arm64': 0.25.11
-      '@esbuild/win32-ia32': 0.25.11
-      '@esbuild/win32-x64': 0.25.11
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -3215,9 +3245,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  jotai-optics@0.3.2(jotai@2.15.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0))(optics-ts@2.4.1):
+  jotai-optics@0.3.2(jotai@2.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(react@19.2.0))(optics-ts@2.4.1):
     dependencies:
-      jotai: 2.15.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0)
+      jotai: 2.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(react@19.2.0)
       optics-ts: 2.4.1
 
   jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.2)(react@19.2.0))(optics-ts@2.4.1):
@@ -3225,9 +3255,9 @@ snapshots:
       jotai: 2.8.4(@types/react@19.2.2)(react@19.2.0)
       optics-ts: 2.4.1
 
-  jotai-x@1.2.4(@types/react@19.2.2)(jotai@2.15.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0):
+  jotai-x@1.2.4(@types/react@19.2.2)(jotai@2.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0):
     dependencies:
-      jotai: 2.15.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0)
+      jotai: 2.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.2
       react: 19.2.0
@@ -3239,10 +3269,10 @@ snapshots:
       '@types/react': 19.2.2
       react: 19.2.0
 
-  jotai@2.15.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0):
+  jotai@2.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.2)(react@19.2.0):
     optionalDependencies:
-      '@babel/core': 7.28.5
-      '@babel/template': 7.27.2
+      '@babel/core': 7.29.7
+      '@babel/template': 7.29.7
       '@types/react': 19.2.2
       react: 19.2.0
 
@@ -3677,9 +3707,9 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  vite@7.1.12(@types/node@24.9.2):
+  vite@7.3.5(@types/node@24.9.2):
     dependencies:
-      esbuild: 0.25.11
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6

--- a/web/ui-customization/src/App.tsx
+++ b/web/ui-customization/src/App.tsx
@@ -29,13 +29,15 @@ function App() {
           useCDN: true,
           styleSheets: [`${baseUrl}comment-thread.css`],
           ui: {
-            commentThread: (instance, id) => {
+            commentThread: (getInstance, id) => {
               const container = document.createElement("div");
               const root = createRoot(container);
 
               return {
                 render: () => container,
                 onMount: () => {
+                  const instance = getInstance();
+
                   root.render(<CommentThread instance={instance} id={id} />);
                 },
                 onUnmount: () => {


### PR DESCRIPTION
## Update Web UI customization examples for Nutrient SDK 1.15.1

Refreshes the two web UI-customization examples to run on the latest SDK and adopt the updated UI customization callback API, plus a round of correctness fixes to the document-editor sidebar.

### Why

The examples were pinned to `@nutrient-sdk/viewer@1.9.1` and used the old UI customization callback signature, where the callback received the `instance` directly. In current SDK versions the callback receives a `getInstance` getter instead, so the examples broke when run against a recent SDK. This bumps both examples to `1.15.1` and migrates them to the new API, then fixes several bugs in the document-editor sidebar that surfaced along the way.

### Changes

**Both examples**
- Bump `@nutrient-sdk/viewer` `1.9.1 → 1.15.1` (lockfiles regenerated).
- Migrate custom UI slot callbacks to the new API: the callback now receives `getInstance` rather than `instance`, so the instance is resolved via `const instance = getInstance()` inside `onMount`.

**`web/ui-customization`**
- Update the `commentThread` slot callback to the `getInstance` signature.

**`web/ui-customization-doc-editor-sidebar`**
- Introduce a `SIDEBAR_ID` constant (`customDocumentEditorSidebar`) used as both the sidebar slot key and the `sidebarMode` view-state value, with a typed cast so a custom id type-checks against the published `sidebarMode` type.
- **Stable page IDs:** build IDs from page index + label instead of the label alone (labels aren't guaranteed unique), and use a monotonic counter for temporary (added/duplicated/imported) pages so IDs don't collide when created within the same millisecond.
- **Page sizing:** track each page's `width`/`height`; new and duplicated pages now match a reference page's dimensions instead of a hardcoded `300×400`.
- **Add page** works with no selection (appends at the end) instead of requiring a selected page; the button is no longer disabled when nothing is selected.
- **Move left** now moves each selected page one slot at a time with individual operations, fixing incorrect results for multi-page selections under a single backward `movePages`.
- **Import document** copies the uploaded file into a fresh `File` before queuing the operation, so it doesn't depend on an original file handle the browser may invalidate before the operation runs.
- **Button enablement:** disable *Remove* when every page is selected (a document must keep at least one page), and disable *Move Left*/*Move Right* when the selection is already at the respective edge.

Original PR: #161 
Related guides PR: https://github.com/PSPDFKit/nutrient-website/pull/2541