### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/byome.yml
+++ b/.github/workflows/byome.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Biome
-        uses: biomejs/setup-biome@v2
+        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2
         with:
           version: latest
       - name: Run Biome

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,10 +15,10 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 'lts/*'
           cache: 'npm'


### PR DESCRIPTION
## Summary

Pins GitHub Actions `uses:` references to verified full-length commit SHAs.

This prepares the repository for orgwide enforcement that blocks unpinned GitHub Actions and reduces supply-chain risk from mutable tags or branches.

## Details

- Replaced mutable external action refs such as `owner/action@vN` with full 40-character commit SHAs.
- Preserved the originally intended tag/version as an inline comment next to each pin.
- Resolved SHAs from the official upstream action repositories using `git ls-remote`.
- For annotated tags, pinned the peeled commit SHA (`refs/tags/<tag>^{}`), not the tag object SHA.
- No workflow behavior, inputs, permissions, or triggers were intentionally changed.